### PR TITLE
eliminate uninitialized warning

### DIFF
--- a/lib/Geo/Privacy.pm
+++ b/lib/Geo/Privacy.pm
@@ -165,6 +165,7 @@ sub has_data_retention_regulations {
 
 sub _normalize_state {
     my ($cc) = @_;
+    $cc ||= '';
     $cc =~ s/\s//g;
     $cc = uc($cc);
     if ( $cc eq 'GB' ) { return 'UK' }


### PR DESCRIPTION
occasionally when called in a loop one might errantly check `undef`. this initializes the $cc value to '' to satisfy `use warnings`.